### PR TITLE
Feat: Add keyword hover with stats and project actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Commands
+
+- Do not run any commands any commands in the agent.
+
 ## Tests
 
 - Do not write new tests unless specifically asked to.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check that will make sure blog post is valid before submitting to endpoint.
 - Endpoint to Fix the validation errors.
 - Self fixing for Content generated in an automated task.
+- Target Keywords that are generated in a Title Suggestion, now get saved to project keywords.
+- You can hover over a Target keyword to get summary stats.
 
 **Fixed**
 - link to the generated blog post upon creation

--- a/core/api/schemas.py
+++ b/core/api/schemas.py
@@ -140,6 +140,9 @@ class KeywordMetricsOut(Schema):
     data_source: str | None = None
     last_fetched_at: str | None = None  # datetime converted to str
     trend_data: list[dict] | None = None
+    is_in_project: bool | None = None
+    in_use: bool | None = None
+    project_keyword_id: int | None = None
 
 
 class AddKeywordOut(Schema):
@@ -207,3 +210,9 @@ class FixGeneratedBlogPostIn(Schema):
 class FixGeneratedBlogPostOut(Schema):
     status: str
     message: str
+
+
+class GetKeywordDetailsOut(Schema):
+    status: str
+    message: str | None = None
+    keyword: KeywordMetricsOut | None = None

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -21,6 +21,7 @@ from core.api.schemas import (
     GenerateTitleSuggestionOut,
     GenerateTitleSuggestionsIn,
     GenerateTitleSuggestionsOut,
+    GetKeywordDetailsOut,
     PostGeneratedBlogPostIn,
     PostGeneratedBlogPostOut,
     ProjectScanIn,
@@ -585,6 +586,75 @@ def delete_project_keyword(request: HttpRequest, data: DeleteProjectKeywordIn):
         )
         return DeleteProjectKeywordOut(
             status="error", message=f"Failed to delete keyword: {str(e)}"
+        )
+
+
+@api.get("/keywords/details", response=GetKeywordDetailsOut, auth=[session_auth])
+def get_keyword_details(request: HttpRequest, keyword_text: str, project_id: int):
+    profile = request.auth
+
+    try:
+        # Verify user has access to the project
+        project = get_object_or_404(Project, id=project_id, profile=profile)
+
+        # Clean the keyword text
+        keyword_text_cleaned = keyword_text.strip().lower()
+        if not keyword_text_cleaned:
+            return GetKeywordDetailsOut(status="error", message="Keyword text cannot be empty")
+
+        # Try to find existing keyword
+        try:
+            keyword = Keyword.objects.get(keyword_text=keyword_text_cleaned)
+        except Keyword.DoesNotExist:
+            # Create new keyword if it doesn't exist
+            keyword = Keyword.objects.create(keyword_text=keyword_text_cleaned)
+            # Try to fetch metrics for the new keyword
+            metrics_fetched = keyword.fetch_and_update_metrics()
+            if not metrics_fetched:
+                logger.warning(
+                    "[GetKeywordDetails] Failed to fetch metrics for new keyword",
+                    keyword_id=keyword.id,
+                    keyword_text=keyword_text_cleaned,
+                    project_id=project_id,
+                )
+
+        # Check if keyword is already in the project and if it's in use
+        project_keyword = ProjectKeyword.objects.filter(project=project, keyword=keyword).first()
+
+        is_in_project = project_keyword is not None
+        in_use = project_keyword.use if project_keyword else False
+
+        # Prepare keyword data
+        keyword_data = {
+            "id": keyword.id,
+            "keyword_text": keyword.keyword_text,
+            "volume": keyword.volume,
+            "cpc_currency": keyword.cpc_currency,
+            "cpc_value": float(keyword.cpc_value) if keyword.cpc_value is not None else None,
+            "competition": keyword.competition,
+            "country": keyword.country,
+            "is_in_project": is_in_project,
+            "in_use": in_use,
+            "project_keyword_id": project_keyword.id if project_keyword else None,
+            "trend_data": [
+                {"value": trend.value, "month": trend.month, "year": trend.year}
+                for trend in keyword.trends.all()
+            ],
+        }
+
+        return GetKeywordDetailsOut(status="success", keyword=keyword_data)
+
+    except Exception as e:
+        logger.error(
+            "[GetKeywordDetails] Failed to get keyword details",
+            error=str(e),
+            exc_info=True,
+            keyword_text=keyword_text,
+            project_id=project_id,
+            profile_id=profile.id,
+        )
+        return GetKeywordDetailsOut(
+            status="error", message=f"Failed to get keyword details: {str(e)}"
         )
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -494,7 +494,14 @@ class Project(BaseModel):
                 )
                 suggestions.append(suggestion)
 
-            return BlogPostTitleSuggestion.objects.bulk_create(suggestions)
+            created_suggestions = BlogPostTitleSuggestion.objects.bulk_create(suggestions)
+
+            # Schedule background tasks to save target keywords for each suggestion
+            for suggestion in created_suggestions:
+                if suggestion.target_keywords:
+                    async_task("core.tasks.save_title_suggestion_keywords", suggestion.id)
+
+            return created_suggestions
 
     def get_a_list_of_links(self):
         agent = Agent(

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -385,6 +385,36 @@ def generate_and_post_blog_post(project_id: int):
         return f"No blog post to post for {project.name}."
 
 
+def save_title_suggestion_keywords(title_suggestion_id: int):
+    title_suggestion = BlogPostTitleSuggestion.objects.get(id=title_suggestion_id)
+
+    if not title_suggestion.target_keywords or not title_suggestion.project:
+        logger.warning(
+            "[Save Title Suggestion Keywords] No target keywords or project found",
+            title_suggestion_id=title_suggestion_id,
+            has_keywords=bool(title_suggestion.target_keywords),
+            has_project=bool(title_suggestion.project),
+        )
+        return "No keywords or project to save"
+
+    saved_keywords_count = 0
+    for keyword_text in title_suggestion.target_keywords:
+        if keyword_text and keyword_text.strip():
+            save_keyword(keyword_text.strip(), title_suggestion.project)
+            saved_keywords_count += 1
+
+    logger.info(
+        "[Save Title Suggestion Keywords] Successfully saved keywords",
+        title_suggestion_id=title_suggestion_id,
+        project_id=title_suggestion.project.id,
+        project_name=title_suggestion.project.name,
+        saved_keywords_count=saved_keywords_count,
+        total_keywords=len(title_suggestion.target_keywords),
+    )
+
+    return f"Saved {saved_keywords_count} keywords for project {title_suggestion.project.name}"
+
+
 def get_and_save_related_keywords(
     project_id: int,
     limit: int = 10,

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -1,5 +1,8 @@
 import pytest
+from django.contrib.auth import get_user_model
 from django.urls import reverse
+
+User = get_user_model()
 
 
 @pytest.mark.django_db

--- a/core/views.py
+++ b/core/views.py
@@ -260,6 +260,15 @@ class ProjectDetailView(LoginRequiredMixin, DetailView):
             posted_count=Count("generated_blog_posts", filter=Q(generated_blog_posts__posted=True))
         ).prefetch_related("generated_blog_posts")
 
+        # Get all project keywords with their usage status for quick lookup
+        project_keywords = {}
+        for pk in project.project_keywords.select_related("keyword").all():
+            project_keywords[pk.keyword.keyword_text.lower()] = {
+                "keyword": pk.keyword,
+                "in_use": pk.use,
+                "project_keyword_id": pk.id,
+            }
+
         # Categorize suggestions based on the annotated posted_count
         posted_suggestions = []
         archived_suggestions = []
@@ -267,6 +276,23 @@ class ProjectDetailView(LoginRequiredMixin, DetailView):
 
         for suggestion in all_suggestions:
             has_posted = suggestion.posted_count > 0
+
+            # Add keyword usage info to each suggestion
+            suggestion.keywords_with_usage = []
+            if suggestion.target_keywords:
+                for keyword_text in suggestion.target_keywords:
+                    keyword_info = project_keywords.get(
+                        keyword_text.lower(),
+                        {"keyword": None, "in_use": False, "project_keyword_id": None},
+                    )
+                    suggestion.keywords_with_usage.append(
+                        {
+                            "text": keyword_text,
+                            "keyword": keyword_info["keyword"],
+                            "in_use": keyword_info["in_use"],
+                            "project_keyword_id": keyword_info["project_keyword_id"],
+                        }
+                    )
 
             if has_posted:
                 posted_suggestions.append(suggestion)
@@ -407,10 +433,39 @@ class GeneratedBlogPostDetailView(LoginRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         generated_post = self.object
+        project = generated_post.project
 
         context["has_pro_subscription"] = self.request.user.profile.has_active_subscription
         context["has_auto_submission_setting"] = AutoSubmissionSetting.objects.filter(
-            project=generated_post.project
+            project=project
         ).exists()
+
+        # Add keyword usage info to the title suggestion
+        if generated_post.title:
+            # Get all project keywords with their usage status for quick lookup
+            project_keywords = {}
+            for pk in project.project_keywords.select_related("keyword").all():
+                project_keywords[pk.keyword.keyword_text.lower()] = {
+                    "keyword": pk.keyword,
+                    "in_use": pk.use,
+                    "project_keyword_id": pk.id,
+                }
+
+            # Add keyword usage info to the suggestion
+            generated_post.title.keywords_with_usage = []
+            if generated_post.title.target_keywords:
+                for keyword_text in generated_post.title.target_keywords:
+                    keyword_info = project_keywords.get(
+                        keyword_text.lower(),
+                        {"keyword": None, "in_use": False, "project_keyword_id": None},
+                    )
+                    generated_post.title.keywords_with_usage.append(
+                        {
+                            "text": keyword_text,
+                            "keyword": keyword_info["keyword"],
+                            "in_use": keyword_info["in_use"],
+                            "project_keyword_id": keyword_info["project_keyword_id"],
+                        }
+                    )
 
         return context

--- a/frontend/src/controllers/keyword_hover_controller.js
+++ b/frontend/src/controllers/keyword_hover_controller.js
@@ -1,0 +1,435 @@
+import { Controller } from "@hotwired/stimulus";
+import * as d3 from "d3";
+import { showMessage } from "../utils/messages";
+
+// Controller to handle keyword hover functionality with summary stats
+export default class extends Controller {
+  static values = { text: String, projectId: Number };
+
+  connect() {
+    this.tooltip = null;
+    this.keywordData = null;
+    this.isLoading = false;
+    this.originalClasses = this.element.className;
+
+    // Store initial styling state
+    this.initialInUse = this.element.classList.contains("text-green-700");
+  }
+
+  disconnect() {
+    this.hideTooltip();
+  }
+
+  async mouseenter(event) {
+    // Prevent multiple simultaneous requests
+    if (this.isLoading) return;
+
+    // Show loading tooltip immediately
+    this.showLoadingTooltip(event);
+
+    // Fetch keyword data if not already cached
+    if (!this.keywordData) {
+      await this.fetchKeywordData();
+    }
+
+    // Update tooltip with actual data
+    this.showDataTooltip(event);
+  }
+
+  mouseleave() {
+    this.hideTooltip();
+  }
+
+  async handleClick(event) {
+    if (!this.keywordData) return;
+
+    event.preventDefault();
+
+    if (!this.keywordData.is_in_project) {
+      // Save keyword to project
+      await this.saveKeyword();
+    } else {
+      // Toggle keyword usage
+      await this.toggleKeywordUsage();
+    }
+  }
+
+  showLoadingTooltip(event) {
+    this.hideTooltip(); // Remove any existing tooltip
+
+    this.tooltip = document.createElement("div");
+    this.tooltip.className = "keyword-tooltip";
+    this.tooltip.innerHTML = `
+      <div class="px-3 py-2 max-w-xs text-xs text-white bg-gray-900 rounded-lg shadow-lg">
+        <div class="flex items-center space-x-2">
+          <div class="w-3 h-3 rounded-full border-2 border-white animate-spin border-t-transparent"></div>
+          <span>Loading keyword data...</span>
+        </div>
+      </div>
+    `;
+
+    this.positionTooltip(event);
+    document.body.appendChild(this.tooltip);
+  }
+
+  showDataTooltip(event) {
+    if (!this.keywordData) return;
+
+    this.hideTooltip(); // Remove loading tooltip
+
+    this.tooltip = document.createElement("div");
+    this.tooltip.className = "keyword-tooltip";
+
+    const { keyword_text, volume, cpc_value, cpc_currency, competition, is_in_project, in_use, trend_data } = this.keywordData;
+
+    // Format numbers for display
+    const formatVolume = (vol) => {
+      if (!vol) return "N/A";
+      if (vol >= 1000000) return `${(vol / 1000000).toFixed(1)}M`;
+      if (vol >= 1000) return `${(vol / 1000).toFixed(1)}K`;
+      return vol.toString();
+    };
+
+    const formatCPC = (value, currency) => {
+      if (!value) return "N/A";
+      const symbol = currency === "usd" ? "$" : currency?.toUpperCase() || "";
+      return `${symbol}${value.toFixed(2)}`;
+    };
+
+    const formatCompetition = (comp) => {
+      if (comp === null || comp === undefined) return "N/A";
+      return `${(comp * 100).toFixed(0)}%`;
+    };
+
+    // Show different content based on whether keyword is in project
+    if (!is_in_project) {
+      this.tooltip.classList.add("cursor-pointer");
+      this.tooltip.innerHTML = `
+        <div class="px-4 py-3 max-w-sm text-xs text-white bg-gray-900 rounded-lg shadow-lg transition-colors cursor-pointer hover:bg-gray-800">
+          <div class="mb-2 text-sm font-semibold text-blue-200">${keyword_text}</div>
+          <div class="py-2 text-center">
+            <div class="mb-1 font-medium text-yellow-300">Click to Save Keyword</div>
+            <div class="text-xs text-gray-400">Add this keyword to your project</div>
+          </div>
+        </div>
+      `;
+
+      // Add click handler to save keyword
+      this.tooltip.addEventListener("click", () => this.saveKeyword());
+    } else {
+      // Create main content
+      let tooltipContent = `
+        <div class="px-4 py-3 max-w-sm text-xs text-white bg-gray-900 rounded-lg shadow-lg transition-colors cursor-pointer hover:bg-gray-800">
+          <div class="mb-2 text-sm font-semibold text-blue-200">${keyword_text}</div>
+          <div class="space-y-1.5">
+            <div class="flex justify-between">
+              <span class="text-gray-300">Search Volume:</span>
+              <span class="font-medium">${formatVolume(volume)}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-300">CPC:</span>
+              <span class="font-medium">${formatCPC(cpc_value, cpc_currency)}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-300">Competition:</span>
+              <span class="font-medium">${formatCompetition(competition)}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-300">In Use:</span>
+              <span class="font-medium ${in_use ? 'text-green-400' : 'text-gray-400'}">${in_use ? 'Yes' : 'No'}</span>
+            </div>
+      `;
+
+      // Add trend chart if data exists
+      if (trend_data && trend_data.length > 0) {
+        tooltipContent += `
+            <div class="pt-2 mt-3 border-t border-gray-700">
+              <div class="mb-2 text-xs text-gray-300">Search Trend</div>
+              <div id="trend-chart-${this.keywordData.id}" class="w-full h-12"></div>
+            </div>
+        `;
+      }
+
+      tooltipContent += `
+          </div>
+          <div class="pt-2 mt-3 text-center border-t border-gray-600">
+            <div class="text-xs text-gray-400">
+              ${in_use ? 'Click to stop using' : 'Click to start using for blog posts'}
+            </div>
+          </div>
+        </div>
+      `;
+
+      this.tooltip.innerHTML = tooltipContent;
+      this.tooltip.classList.add("cursor-pointer");
+
+      // Add click handler to toggle keyword usage
+      this.tooltip.addEventListener("click", () => this.toggleKeywordUsage());
+
+      // Render trend chart if data exists
+      if (trend_data && trend_data.length > 0) {
+        setTimeout(() => {
+          this.renderTrendChart(`trend-chart-${this.keywordData.id}`, trend_data);
+        }, 10);
+      }
+    }
+
+    this.positionTooltip(event);
+    document.body.appendChild(this.tooltip);
+  }
+
+  positionTooltip(event) {
+    if (!this.tooltip) return;
+
+    const tooltipRect = this.tooltip.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let left = event.pageX + 10;
+    let top = event.pageY - 10;
+
+    // Adjust horizontal position if tooltip would go off-screen
+    if (left + tooltipRect.width > viewportWidth) {
+      left = event.pageX - tooltipRect.width - 10;
+    }
+
+    // Adjust vertical position if tooltip would go off-screen
+    if (top + tooltipRect.height > viewportHeight) {
+      top = event.pageY - tooltipRect.height - 10;
+    }
+
+    // Ensure tooltip doesn't go above viewport
+    if (top < 0) {
+      top = event.pageY + 20;
+    }
+
+    this.tooltip.style.position = "absolute";
+    this.tooltip.style.left = `${left}px`;
+    this.tooltip.style.top = `${top}px`;
+    this.tooltip.style.zIndex = "1000";
+    this.tooltip.style.pointerEvents = "none";
+  }
+
+  hideTooltip() {
+    if (this.tooltip) {
+      this.tooltip.remove();
+      this.tooltip = null;
+    }
+  }
+
+  async fetchKeywordData() {
+    if (this.isLoading) return;
+
+    this.isLoading = true;
+
+    try {
+      const response = await fetch(`/api/keywords/details?keyword_text=${encodeURIComponent(this.textValue)}&project_id=${this.projectIdValue}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": this.getCSRFToken(),
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      if (data.status === "success") {
+        this.keywordData = data.keyword;
+        this.updateChipStyling();
+      } else {
+        console.warn("Failed to fetch keyword data:", data.message);
+        this.keywordData = {
+          keyword_text: this.textValue,
+          volume: null,
+          cpc_value: null,
+          cpc_currency: null,
+          competition: null,
+          is_in_project: false,
+          in_use: false,
+          project_keyword_id: null,
+          trend_data: null
+        };
+      }
+    } catch (error) {
+      console.error("Error fetching keyword data:", error);
+      // Set fallback data
+      this.keywordData = {
+        keyword_text: this.textValue,
+        volume: null,
+        cpc_value: null,
+        cpc_currency: null,
+        competition: null,
+        is_in_project: false,
+        in_use: false,
+        project_keyword_id: null,
+        trend_data: null
+      };
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  renderTrendChart(containerId, trendData) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    const { width, height } = container.getBoundingClientRect();
+    const padding = { top: 2, right: 2, bottom: 2, left: 2 };
+
+    const svg = d3.select(container)
+      .append("svg")
+      .attr("width", width)
+      .attr("height", height);
+
+    // X Scale
+    const xScale = d3.scaleLinear()
+      .domain([0, trendData.length - 1])
+      .range([padding.left, width - padding.right]);
+
+    // Y Scale
+    let yMin = d3.min(trendData, d => d.value);
+    let yMax = d3.max(trendData, d => d.value);
+
+    // Handle edge cases
+    if (yMin === yMax) {
+      yMin = yMin > 0 ? yMin * 0.9 : yMin * 1.1;
+      yMax = yMax > 0 ? yMax * 1.1 : yMax * 0.9;
+    }
+
+    const yScale = d3.scaleLinear()
+      .domain([yMin, yMax])
+      .range([height - padding.bottom, padding.top]);
+
+    // Create line generator
+    const line = d3.line()
+      .x((d, i) => xScale(i))
+      .y(d => yScale(d.value))
+      .curve(d3.curveMonotoneX);
+
+    // Create area generator
+    const area = d3.area()
+      .x((d, i) => xScale(i))
+      .y0(height - padding.bottom)
+      .y1(d => yScale(d.value))
+      .curve(d3.curveMonotoneX);
+
+    // Add area fill
+    svg.append("path")
+      .datum(trendData)
+      .attr("class", "area")
+      .attr("d", area)
+      .attr("fill", "#60A5FA")
+      .attr("fill-opacity", 0.2);
+
+    // Add line
+    svg.append("path")
+      .datum(trendData)
+      .attr("class", "line")
+      .attr("d", line)
+      .attr("fill", "none")
+      .attr("stroke", "#60A5FA")
+      .attr("stroke-width", 1.5);
+  }
+
+  async saveKeyword() {
+    if (!this.keywordData || this.keywordData.is_in_project) return;
+
+    try {
+      const response = await fetch("/api/keywords/add", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": this.getCSRFToken(),
+        },
+        body: JSON.stringify({
+          project_id: this.projectIdValue,
+          keyword_text: this.textValue.trim()
+        })
+      });
+
+      const data = await response.json();
+
+      if (data.status === "success") {
+        showMessage("Keyword added to project successfully!", "success");
+        // Update the cached data to reflect that it's now in the project
+        this.keywordData.is_in_project = true;
+        this.keywordData.in_use = false; // New keywords start as not in use
+        this.keywordData.project_keyword_id = data.keyword.id;
+        this.updateChipStyling();
+        this.hideTooltip();
+      } else {
+        showMessage(data.message || "Failed to add keyword to project.", "error");
+      }
+    } catch (error) {
+      console.error("Error saving keyword:", error);
+      showMessage("An error occurred while saving the keyword.", "error");
+    }
+  }
+
+  async toggleKeywordUsage() {
+    if (!this.keywordData || !this.keywordData.is_in_project || !this.keywordData.project_keyword_id) return;
+
+    try {
+      const response = await fetch("/api/keywords/toggle-use", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": this.getCSRFToken(),
+        },
+        body: JSON.stringify({
+          project_id: this.projectIdValue,
+          keyword_id: this.keywordData.id
+        })
+      });
+
+      const data = await response.json();
+
+      if (data.status === "success") {
+        this.keywordData.in_use = data.use;
+        this.updateChipStyling();
+
+        const message = data.use
+          ? "Keyword is now in use for blog posts!"
+          : "Keyword usage disabled.";
+        showMessage(message, "success");
+
+        this.hideTooltip();
+      } else {
+        showMessage(data.message || "Failed to toggle keyword usage.", "error");
+      }
+    } catch (error) {
+      console.error("Error toggling keyword usage:", error);
+      showMessage("An error occurred while updating keyword usage.", "error");
+    }
+  }
+
+  updateChipStyling() {
+    if (!this.keywordData) return;
+
+    // Apply green accent if keyword is in use
+    if (this.keywordData.in_use) {
+      this.element.classList.remove("text-gray-600", "bg-gray-50", "border-gray-200", "hover:bg-gray-100");
+      this.element.classList.add("text-green-700", "bg-green-50", "border-green-200", "hover:bg-green-100");
+    } else {
+      this.element.classList.remove("text-green-700", "bg-green-50", "border-green-200", "hover:bg-green-100");
+      this.element.classList.add("text-gray-600", "bg-gray-50", "border-gray-200", "hover:bg-gray-100");
+    }
+  }
+
+  getCSRFToken() {
+    // Try to get CSRF token from cookie (Django default)
+    const name = "csrftoken";
+    const cookies = document.cookie.split(";");
+    for (let i = 0; i < cookies.length; i++) {
+      let cookie = cookies[i].trim();
+      if (cookie.startsWith(name + "=")) {
+        return decodeURIComponent(cookie.substring(name.length + 1));
+      }
+    }
+    return "";
+  }
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -20,4 +20,15 @@
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     transition-duration: 200ms;
   }
+
+  /* Keyword tooltip styles */
+  .keyword-tooltip {
+    z-index: 1000;
+    pointer-events: none;
+  }
+
+  /* Make tooltip clickable when it has cursor-pointer class */
+  .keyword-tooltip.cursor-pointer {
+    pointer-events: auto;
+  }
 }

--- a/frontend/templates/components/blog_post_suggestion_card.html
+++ b/frontend/templates/components/blog_post_suggestion_card.html
@@ -113,10 +113,8 @@
             Keywords
           </h5>
           <div class="flex flex-wrap gap-2">
-            {% for keyword in suggestion.target_keywords %}
-              <span class="inline-flex items-center px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-50 rounded-full border border-gray-200 transition-colors hover:bg-gray-100">
-                {{ keyword }}
-              </span>
+            {% for keyword_data in suggestion.keywords_with_usage %}
+              {% include "components/keyword_chip.html" with keyword=keyword_data.text project_id=suggestion.project.id keyword_in_use=keyword_data.in_use %}
             {% endfor %}
           </div>
         </div>

--- a/frontend/templates/components/keyword_chip.html
+++ b/frontend/templates/components/keyword_chip.html
@@ -1,0 +1,8 @@
+<!-- Keyword chip component with hover functionality -->
+<span class="inline-flex items-center px-3 py-1.5 text-xs font-medium {% if keyword_in_use %}text-green-700 bg-green-50 border-green-200 hover:bg-green-100{% else %}text-gray-600 bg-gray-50 border-gray-200 hover:bg-gray-100{% endif %} rounded-full border transition-colors cursor-pointer"
+      data-controller="keyword-hover"
+      data-keyword-hover-text-value="{{ keyword }}"
+      data-keyword-hover-project-id-value="{{ project_id }}"
+      data-action="mouseenter->keyword-hover#mouseenter mouseleave->keyword-hover#mouseleave click->keyword-hover#handleClick">
+  {{ keyword }}
+</span>


### PR DESCRIPTION
Implemented a new feature allowing users to hover over target keyword chips to view detailed metrics and manage them. Additionally, keywords from generated blog post title suggestions are now automatically saved to the project.

This enhances keyword management by automatically capturing relevant keywords and provides immediate, actionable insights into keyword performance directly within the UI. Users can now quickly decide to save a keyword or toggle its 'in use' status without navigating away.

Technical Details:
- A new API endpoint (`/api/keywords/details`) fetches comprehensive keyword data, including search volume, CPC, competition, and trend data.
- A StimulusJS controller (`keyword_hover_controller.js`) handles the frontend interaction, displaying a dynamic tooltip powered by D3.js for trend visualizations.
- The tooltip allows users to save a keyword to their project or toggle its 'in use' status, interacting with existing API endpoints (`/api/keywords/add` and `/api/keywords/toggle-use`).
- A new `async_task` (`save_title_suggestion_keywords`) ensures that all target keywords identified in `BlogPostTitleSuggestion` are automatically added to the associated project's keywords.
- Django views (`ProjectDetailView`, `GeneratedBlogPostDetailView`) were updated to pass keyword usage status to templates, enabling proper initial styling for keyword chips.