### PR TITLE
Fix: Ensure blog post validation and retry generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Change**
 - Generate More Ideas now shows up all the time
 
+**Fixed**
+- actually run validations now
+
 
 ## [0.0.7] - 2025-10-04
 **Added**

--- a/core/models.py
+++ b/core/models.py
@@ -847,7 +847,7 @@ class BlogPostTitleSuggestion(BaseModel):
             model_name="BlogPostTitleSuggestion",
         )
 
-        return GeneratedBlogPost.objects.create(
+        return GeneratedBlogPost.objects.create_and_validate(
             project=self.project,
             title=self,
             description=result.data.description,
@@ -920,7 +920,7 @@ class GeneratedBlogPost(BaseModel):
     posted = models.BooleanField(default=False)
     date_posted = models.DateTimeField(null=True, blank=True)
 
-    # Validation Issues - Not guilty until proven guilty
+    # Validation Issues - Innocent until proven guilty
     content_too_short = models.BooleanField(default=False)
     has_valid_ending = models.BooleanField(default=True)
     placeholders = models.BooleanField(default=False)
@@ -955,28 +955,36 @@ class GeneratedBlogPost(BaseModel):
         """Run validation and update fields in a single query."""
         from core.utils import blog_post_has_placeholders, blog_post_has_valid_ending
 
+        base_logger_info = {
+            "blog_post_id": self.id,
+            "project_id": self.project.id,
+            "project_name": self.project.name,
+            "profile_id": self.project.profile.id,
+            "profile_email": self.project.profile.user.email,
+        }
+
+        logger.info("[Validation] Running validation", **base_logger_info)
+
         if not self.content:
-            content_too_short = True
-            has_valid_ending = False
-            placeholders = False
+            self.content_too_short = True
+            self.has_valid_ending = False
+            self.placeholders = False
 
-        content = self.content.strip()
+        else:
+            content = self.content.strip()
+            self.content_too_short = len(content) < 3000
+            self.has_valid_ending = blog_post_has_valid_ending(self)
+            self.placeholders = blog_post_has_placeholders(self)
 
-        content_too_short = len(content) < 3000
-        has_valid_ending = blog_post_has_valid_ending(self)
-        placeholders = blog_post_has_placeholders(self)
-
-        self.content_too_short = content_too_short
-        self.has_valid_ending = has_valid_ending
-        self.placeholders = placeholders
         self.save(update_fields=["content_too_short", "has_valid_ending", "placeholders"])
 
         logger.info(
             "[Validation] Blog post validation complete",
-            blog_post_id=self.id,
-            content_too_short=content_too_short,
-            has_valid_ending=has_valid_ending,
-            placeholders=placeholders,
+            **base_logger_info,
+            blog_post_title=self.title.title,
+            content_too_short=self.content_too_short,
+            has_valid_ending=self.has_valid_ending,
+            placeholders=self.placeholders,
         )
 
     def submit_blog_post_to_endpoint(self):

--- a/core/models.py
+++ b/core/models.py
@@ -957,7 +957,7 @@ class GeneratedBlogPost(BaseModel):
 
         base_logger_info = {
             "blog_post_id": self.id,
-            "project_id": self.project.id,
+            "project_id": self.project_id,
             "project_name": self.project.name,
             "profile_id": self.project.profile.id,
             "profile_email": self.project.profile.user.email,

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -360,6 +360,12 @@ def generate_and_post_blog_post(project_id: int):
                 project_name=project.name,
             )
             blog_post_to_post.fix_generated_blog_post()
+            async_task(
+                "core.tasks.generate_and_post_blog_post",
+                project.id,
+                group="Re-run Blog Post Generation/Posting",
+            )
+            return "Fixed blog post content and scheduled re-generation/posting."
 
         logger.info(
             "[Generate and Post Blog Post] Submitting blog post to endpoint",


### PR DESCRIPTION
This commit addresses an issue where blog post validations were not consistently running or being applied correctly.

Changes include:
- Modified `BlogPostTitleSuggestion.generate_blog_post_from_title()` to use `GeneratedBlogPost.objects.create_and_validate()`, ensuring that validations are run immediately when a blog post is first created.
- Refactored `GeneratedBlogPost.run_validation()` to correctly set and persist validation flags (e.g., `content_too_short`, `placeholders`) on the blog post instance, especially when content is empty.
- Updated `generate_and_post_blog_post` task to re-schedule itself asynchronously if a blog post required an automatic fix. This ensures that the system attempts to process and post the corrected blog post.
- Added more detailed logging to the `run_validation()` method.

These changes guarantee that blog posts are validated upon creation and that the system attempts to re-process fixed blog posts, preventing invalid content from being overlooked and improving the overall reliability of the generation and posting workflow.